### PR TITLE
Add ad-chapter plugin capability

### DIFF
--- a/plugin/host/README.md
+++ b/plugin/host/README.md
@@ -54,10 +54,12 @@ For each applicable episode, `RemoteMediaProcessor`:
 
 ## Capabilities
 
-Plugins declare a capability bitmask (`CAPABILITY_TRANSCRIPTION`, `CAPABILITY_CHAPTERS`). For each
-download, `RemoteMediaProcessor` requests every capability the plugin supports that the episode still
-needs, one binder call each, and applies the results: transcripts via `TranscriptUtils.storeTranscript`
-and chapters via `item.setChapters` + `DBWriter.setFeedItem`.
+Plugins declare a capability bitmask (`CAPABILITY_TRANSCRIPTION`, `CAPABILITY_CHAPTERS`,
+`CAPABILITY_AD_CHAPTERS`). For each download, `RemoteMediaProcessor` requests every capability the
+plugin supports that the episode still needs, one binder call each, and applies the results:
+transcripts via `TranscriptUtils.storeTranscript`, chapters via `item.setChapters` +
+`DBWriter.setFeedItem`, and ad-chapter markers via a merge-and-dedup strategy that inserts ad markers
+into existing chapter lists without duplicating near-identical timestamps (1s tolerance).
 
 ## Live discovery
 

--- a/plugin/host/src/main/java/de/danoeh/antennapod/plugin/host/PluginContract.java
+++ b/plugin/host/src/main/java/de/danoeh/antennapod/plugin/host/PluginContract.java
@@ -8,9 +8,11 @@ public final class PluginContract {
 
     public static final int CAPABILITY_TRANSCRIPTION = 1;
     public static final int CAPABILITY_CHAPTERS = 1 << 1;
+    public static final int CAPABILITY_AD_CHAPTERS = 1 << 2;
     public static final int RESULT_TYPE_NONE = 0;
     public static final int RESULT_TYPE_TRANSCRIPT = 1;
     public static final int RESULT_TYPE_CHAPTERS = 2;
+    public static final int RESULT_TYPE_AD_CHAPTERS = 3;
 
     private PluginContract() {
     }

--- a/plugin/host/src/main/java/de/danoeh/antennapod/plugin/host/RemoteMediaProcessor.java
+++ b/plugin/host/src/main/java/de/danoeh/antennapod/plugin/host/RemoteMediaProcessor.java
@@ -16,6 +16,7 @@ import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.model.playback.MediaType;
 import de.danoeh.antennapod.plugin.api.DownloadedMediaProcessor;
 import de.danoeh.antennapod.plugin.api.PluginDebugLog;
+import de.danoeh.antennapod.storage.database.DBReader;
 import de.danoeh.antennapod.storage.database.DBWriter;
 import de.danoeh.antennapod.ui.transcript.TranscriptUtils;
 import org.apache.commons.io.IOUtils;
@@ -23,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -30,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 public class RemoteMediaProcessor implements DownloadedMediaProcessor {
     private static final String TAG = "RemoteMediaProcessor";
     private static final long BIND_TIMEOUT_MS = 15000;
+    private static final long AD_CHAPTER_TOLERANCE_MS = 1000;
 
     private final Context appContext;
     private final PluginDescriptor descriptor;
@@ -129,6 +132,8 @@ public class RemoteMediaProcessor implements DownloadedMediaProcessor {
                     + " length=" + (content == null ? 0 : content.length());
         } else if (result.getResultType() == PluginContract.RESULT_TYPE_CHAPTERS) {
             return "chapters count=" + result.getChapters().size();
+        } else if (result.getResultType() == PluginContract.RESULT_TYPE_AD_CHAPTERS) {
+            return "ad chapters count=" + result.getChapters().size();
         }
         return "resultType=" + result.getResultType();
     }
@@ -147,6 +152,9 @@ public class RemoteMediaProcessor implements DownloadedMediaProcessor {
                 && (item.getChapters() == null || item.getChapters().isEmpty())
                 && item.getPodcastIndexChapterUrl() == null) {
             capabilities.add(PluginContract.CAPABILITY_CHAPTERS);
+        }
+        if (descriptor.hasCapability(PluginContract.CAPABILITY_AD_CHAPTERS)) {
+            capabilities.add(PluginContract.CAPABILITY_AD_CHAPTERS);
         }
         return capabilities;
     }
@@ -176,6 +184,8 @@ public class RemoteMediaProcessor implements DownloadedMediaProcessor {
             applyTranscript(media, result);
         } else if (result.getResultType() == PluginContract.RESULT_TYPE_CHAPTERS) {
             applyChapters(media, result);
+        } else if (result.getResultType() == PluginContract.RESULT_TYPE_AD_CHAPTERS) {
+            applyAdChapters(media, result);
         }
     }
 
@@ -216,6 +226,52 @@ public class RemoteMediaProcessor implements DownloadedMediaProcessor {
         Log.d(TAG, "Applied " + chapters.size() + " chapters from plugin " + descriptor.getId());
         PluginDebugLog.info(TAG, "Applied " + chapters.size() + " chapters from plugin '"
                 + descriptor.getId() + "'");
+    }
+
+    private void applyAdChapters(FeedMedia media, PluginMediaResult result) {
+        FeedItem item = media.getItem();
+        if (item == null || result.getChapters().isEmpty()) {
+            PluginDebugLog.warn(TAG, "Ignoring ad chapters from '" + descriptor.getId()
+                    + "': missing item or empty chapter list");
+            return;
+        }
+        List<Chapter> existing = item.getChapters();
+        if (existing == null && item.hasChapters()) {
+            existing = DBReader.loadChaptersOfFeedItem(item);
+        }
+        List<Chapter> merged = new ArrayList<>();
+        if (existing != null) {
+            merged.addAll(existing);
+        }
+        int inserted = 0;
+        for (PluginChapter chapter : result.getChapters()) {
+            if (StringUtils.isEmpty(chapter.getTitle()) || hasChapterNear(merged, chapter.getStartMs())) {
+                continue;
+            }
+            merged.add(new Chapter(chapter.getStartMs(), chapter.getTitle(),
+                    chapter.getUrl(), chapter.getImageUrl()));
+            inserted++;
+        }
+        if (inserted == 0) {
+            PluginDebugLog.info(TAG, "Plugin '" + descriptor.getId()
+                    + "' returned no ad chapters that are not already present");
+            return;
+        }
+        Collections.sort(merged, (first, second) -> Long.compare(first.getStart(), second.getStart()));
+        item.setChapters(merged);
+        DBWriter.setFeedItem(item, false);
+        Log.d(TAG, "Inserted " + inserted + " ad chapters from plugin " + descriptor.getId());
+        PluginDebugLog.info(TAG, "Inserted " + inserted + " ad chapter marker(s) from plugin '"
+                + descriptor.getId() + "' into " + merged.size() + " total chapters");
+    }
+
+    private static boolean hasChapterNear(List<Chapter> chapters, long startMs) {
+        for (Chapter chapter : chapters) {
+            if (Math.abs(chapter.getStart() - startMs) < AD_CHAPTER_TOLERANCE_MS) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static class BlockingServiceConnection implements ServiceConnection {


### PR DESCRIPTION
### Description

Adds `CAPABILITY_AD_CHAPTERS` / `RESULT_TYPE_AD_CHAPTERS` so a plugin can mark advertising breaks on the episode timeline. Ad breaks are expressed as ordinary chapters — one marker where the break starts, one where the programme resumes — so skipping an ad is just "next chapter", with no player changes, no new storage, and no new UI. The host applies whatever titles the plugin supplies (for example `Ad break 1 (1:05)` / `Content resumes`) and never synthesises them.

Two host behaviours differ from the existing `CAPABILITY_CHAPTERS`, and they are the whole of the change. The capability is requested **even when the episode already has chapters** — an episode with publisher chapters is exactly where ad markers still help — and its result is **merged** into the existing list rather than replacing it: existing chapters are loaded first (via `DBReader.loadChaptersOfFeedItem` when the item only carries the `hasChapters` flag), a returned marker within one second of an existing chapter is dropped so the list never grows two indistinguishable entries, and the merged list is sorted by start time. Nothing is skipped or muted automatically; the timeline is labelled and the listener decides.

The companion plugin app is in its own repository ([antennapod-ad-chapter-plugin](https://github.com/tonytamsf/antennapod-ad-chapter-plugin), PR 1): it decodes the episode on device, extracts per-500ms loudness/zero-crossing/spectral-centroid features, and scores silence-fenced blocks against the episode's own baseline. Docs updated alongside — the architecture doc gains a section on additive capabilities and the merge rules, `plugin/host/README.md` gains the new bit, and the extension roadmap records this as the shipped first increment of its E1 segment-provider proposal, with the segment model proper (categories, confidence, automatic skip) still outstanding.

Verified with `./gradlew :app:assembleDebug` and `./gradlew checkstyle`, both passing. Stacked on the roadmap-doc branch.

### Checklist

- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style 
- [ ] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] If it is a core feature, I have added automated tests

---
_Generated by [Claude Code](https://claude.ai/code/session_019Q1XBwoPnTULqt8QWAdaYE)_