### PR TITLE
Plugin system: downloaded episodes pipeline integration

### DIFF
--- a/net/download/service/build.gradle
+++ b/net/download/service/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     alias(libs.plugins.android.library)
+    id("java-test-fixtures")
 }
 apply from: "../../../common.gradle"
 apply from: "../../../playFlavor.gradle"
-apply from: "../../../mockitoAgent.gradle"
 
 android {
     namespace "de.danoeh.antennapod.net.download.service"
@@ -15,6 +15,8 @@ dependencies {
     implementation project(':net:common')
     implementation project(':net:download:service-interface')
     implementation project(':net:sync:service-interface')
+    implementation project(':plugin:api')
+    implementation project(':plugin:host')
     implementation project(':parser:media')
     implementation project(':parser:feed')
     implementation project(':storage:database')

--- a/net/download/service/src/main/AndroidManifest.xml
+++ b/net/download/service/src/main/AndroidManifest.xml
@@ -5,6 +5,12 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <queries>
+        <intent>
+            <action android:name="de.danoeh.antennapod.plugin.action.MEDIA_PROCESSOR"/>
+        </intent>
+    </queries>
+
     <application
         android:allowBackup="true"
         android:supportsRtl="true">

--- a/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/MediaDownloadedHandler.java
+++ b/net/download/service/src/main/java/de/danoeh/antennapod/net/download/service/episode/MediaDownloadedHandler.java
@@ -24,6 +24,7 @@ import de.danoeh.antennapod.model.download.DownloadError;
 import de.danoeh.antennapod.model.feed.FeedItem;
 import de.danoeh.antennapod.model.feed.FeedMedia;
 import de.danoeh.antennapod.net.sync.serviceinterface.EpisodeAction;
+import de.danoeh.antennapod.plugin.api.MediaProcessorRegistry;
 import de.danoeh.antennapod.ui.transcript.TranscriptUtils;
 
 /**
@@ -115,6 +116,8 @@ public class MediaDownloadedHandler implements Runnable {
                         .currentTimestamp()
                         .build());
         }
+
+        MediaProcessorRegistry.runAll(context, media);
     }
 
     @NonNull


### PR DESCRIPTION
### Description

Wires the plugin architecture from #18 into the download pipeline. After each episode download, `MediaDownloadedHandler` calls `MediaProcessorRegistry.runAll()` to invoke any enabled plugins (transcription, chapters). Adds the episode-retention extension point with AIDL contract (`IEpisodeRetentionPlugin`) and `EpisodeRetentionManager`, called from `AutoDownloadManager` to let plugins control per-podcast episode limits. Updates the Plugins settings screen to also discover retention plugins.

Depends on #18. Split from #14.

### Checklist
- [x] I have read the contribution guidelines: https://github.com/AntennaPod/AntennaPod/blob/develop/CONTRIBUTING.md#submit-a-pull-request
- [x] I have performed a self-review of my code, going through my changes line by line and carefully considering why this line change is necessary
- [x] I have run the automated code checks using `./gradlew checkstyle lint`
- [x] My code follows the style guidelines of the AntennaPod project: https://antennapod.org/contribute/develop/app/code-style
- [x] I have mentioned the corresponding issue and the relevant keyword (e.g., "Closes: #xy") in the description (see https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] If it is a core feature, I have added automated tests